### PR TITLE
Update SDKs to 21 & remove manifest icon

### DIFF
--- a/CardStack/build.gradle
+++ b/CardStack/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 14
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 21
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 21
         versionCode 1
         versionName "1.0"
     }
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:20.0.+'
+    compile 'com.android.support:appcompat-v7:21.0.2'
 
 }

--- a/CardStack/src/main/AndroidManifest.xml
+++ b/CardStack/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <application android:allowBackup="true"
         android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher"
 >
 
     </application>

--- a/DemoApp/build.gradle
+++ b/DemoApp/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 21
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         applicationId "wxj.swipeablecardstack"
@@ -31,5 +31,5 @@ dependencies {
     //compile(name:'android-card-stack-0.1.0', ext:'aar')
     //http://stackoverflow.com/questions/21170395/how-to-include-a-library-module-dependency-in-an-android-studio-project
     compile project(":CardStack")
-    compile 'com.android.support:appcompat-v7:20.0.+'
+    compile 'com.android.support:appcompat-v7:21.0.2'
 }


### PR DESCRIPTION
I removed the icon from the CardStack project because I had a problem related to it in my project, where the solution happened to be, adding tools:replace="android:icon" in my app's manifest.
https://github.com/pedant/sweet-alert-dialog/issues/33

It's an issue but I think this pull might help fixing it in the future. 

Also I updated the sdk to 21.
