### PR TITLE
Stop parent intercepting touch event

### DIFF
--- a/CardStack/src/main/java/com/wenchao/cardstack/CardStack.java
+++ b/CardStack/src/main/java/com/wenchao/cardstack/CardStack.java
@@ -200,6 +200,7 @@ public class CardStack extends RelativeLayout {
             private static final String DEBUG_TAG = "MotionEvents";
             @Override
             public boolean onTouch(View arg0, MotionEvent event) {
+                CardStack.this.requestDisallowInterceptTouchEvent(true);
                 dd.onTouchEvent(event);
                 return true;
             }


### PR DESCRIPTION
In case we use the CardStack in a ScrollView, or other parent that would would intercept the touch event and make an unnecessary action.
By calling requestDisallowInterceptTouchEvent(true), the card stack will handle the touch events inside it on it's own, guaranteeing smooth animation.
